### PR TITLE
add fastifySeverOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
+import { type Server } from 'node:https';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { getPrismaClient } from '@prisma/client/runtime/library.js';
-import { fastify } from 'fastify';
+import { fastify, type FastifyServerOptions, type FastifyHttpsOptions } from 'fastify';
 import forge from 'node-forge';
 import pg from 'pg';
 import { PrismaAccelerate } from './prisma-accelerate.js';
@@ -61,17 +62,20 @@ const getAdapter = (datasourceUrl: string) => {
   });
 };
 
-export const createServer = ({
-  datasourceUrl,
-  https,
-  wasm,
-  secret,
-}: {
-  datasourceUrl?: string;
-  https?: { cert: string; key: string } | null;
-  wasm?: boolean;
-  secret?: string;
-}) => {
+export const createServer = (
+  {
+    datasourceUrl,
+    https,
+    wasm,
+    secret,
+  }: {
+    datasourceUrl?: string;
+    https?: { cert: string; key: string } | null;
+    wasm?: boolean;
+    secret?: string;
+  },
+  fastifySeverOptions?: FastifyServerOptions = {}
+) => {
   const prismaAccelerate = new PrismaAccelerate({
     secret,
     datasourceUrl,
@@ -89,7 +93,10 @@ export const createServer = ({
       return new WebAssembly.Module(queryEngineWasmFileBytes);
     },
   });
-  return fastify({ https: https === undefined ? createKey() : https })
+  return fastify({
+    ...fastifySeverOptions,
+    https: https === undefined ? createKey() : https,
+  } as FastifyHttpsOptions<Server>)
     .post('/:version/:hash/graphql', async ({ body, params, headers }, reply) => {
       const { hash } = params as { hash: string };
       return prismaAccelerate.query({ hash, headers, body }).catch((e) => {


### PR DESCRIPTION
Add an optional second parameter to the `createServer` function to allow passing in extra [Fastify server factory options](https://fastify.dev/docs/latest/Reference/Server/#factory).

My use case is to set higher [bodylimit](https://fastify.dev/docs/latest/Reference/Server/#bodylimit), the default 1Mib is too low for larger operations.

Passing `bodylimit` in the `server.listen()` options doesn't work in this case.
